### PR TITLE
Return response even if promptLayer call fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "promptlayer",
   "license": "MIT",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as prompts from "@/prompts";
 import * as track from "@/track";
 import * as utils from "@/utils";
 
-const dynamicExports = new Proxy<{
+export const promptlayer = new Proxy<{
   OpenAI: any;
   Anthropic: any;
   api_key: string | undefined;
@@ -37,5 +37,3 @@ const dynamicExports = new Proxy<{
     },
   }
 );
-
-export default dynamicExports;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,12 +53,12 @@ const promptLayerApiRequest = async (body: TrackRequest) => {
     if (data && body.return_pl_id) {
       return [body.request_response, data.request_id];
     }
-    return body.request_response;
   } catch (e) {
     console.warn(
       `WARNING: While logging your request PromptLayer had the following error: ${e}`
     );
   }
+  return body.request_response;
 };
 
 const promptLayerAllPromptTemplates = async (params?: Pagination) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import promptlayer from "@/index";
+import { promptlayer } from "@/index";
 import {
   GetPromptTemplate,
   Pagination,


### PR DESCRIPTION
Previously, if the promptLayer API call failed, the function would not return any response. This PR ensures that the function always returns the response, even if the promptLayer call fails.

This PR also moves to named export instead of default export. This means, 
```ts
import promptlayer from "promptlayer";
//this becomes
import { promptlayer } from "promptlayer";
```