### PR TITLE
52 - Add function for fetching all prompt templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promptlayer",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promptlayer",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "MIT",
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "promptlayer",
   "license": "MIT",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,5 +1,13 @@
-import { GetPromptTemplateParams, PublishPromptTemplate } from "@/types";
-import { getPromptTemplate, publishPromptTemplate } from "@/utils";
+import {
+  GetPromptTemplateParams,
+  Pagination,
+  PublishPromptTemplate,
+} from "@/types";
+import {
+  getAllPromptTemplates,
+  getPromptTemplate,
+  publishPromptTemplate,
+} from "@/utils";
 
 export const get = (
   promptName: string,
@@ -8,3 +16,5 @@ export const get = (
 
 export const publish = (body: PublishPromptTemplate) =>
   publishPromptTemplate(body);
+
+export const all = (params?: Pagination) => getAllPromptTemplates(params);

--- a/src/types.ts
+++ b/src/types.ts
@@ -228,4 +228,10 @@ export interface PublishPromptTemplateResponse
 
 export interface GetPromptTemplateResponse extends BasePromptTemplateResponse {
   version: number;
+  llm_kwargs: Record<string, unknown> | null;
+}
+
+export interface ListPromptTemplatesResponse
+  extends BasePromptTemplateResponse {
+  version: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,11 +214,18 @@ export type PromptVersion = {
 
 export type PublishPromptTemplate = BasePromptTemplate & PromptVersion;
 
-export type PublishPromptTemplateResponse = {
+export interface BasePromptTemplateResponse {
   id: number;
   prompt_name: string;
   tags: string[];
   prompt_template: PromptTemplate;
   commit_message?: string;
   metadata?: Metadata;
-};
+}
+
+export interface PublishPromptTemplateResponse
+  extends BasePromptTemplateResponse {}
+
+export interface GetPromptTemplateResponse extends BasePromptTemplateResponse {
+  version: number;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ import { promptlayer } from "@/index";
 import {
   GetPromptTemplate,
   GetPromptTemplateParams,
+  GetPromptTemplateResponse,
   LegacyPublishPromptTemplate,
   Pagination,
   PublishPromptTemplate,
@@ -341,7 +342,7 @@ const getPromptTemplate = async (
       );
       return null;
     }
-    return data;
+    return data as Promise<GetPromptTemplateResponse>;
   } catch (e) {
     console.warn(
       `WARNING: While fetching a prompt template PromptLayer had the following error: ${e}`
@@ -378,6 +379,35 @@ const publishPromptTemplate = async (body: PublishPromptTemplate) => {
     console.warn(
       `WARNING: While publishing a prompt template PromptLayer had the following error: ${e}`
     );
+  }
+};
+
+const getAllPromptTemplates = async (params?: Partial<Pagination>) => {
+  try {
+    const url = new URL(`${URL_API_PROMPTLAYER}/prompt-templates`);
+    Object.entries(params || {}).forEach(([key, value]) =>
+      url.searchParams.append(key, value.toString())
+    );
+    const response = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-KEY": getApiKey(),
+      },
+    });
+    const data = await response.json();
+    if (response.status !== 200) {
+      warnOnBadResponse(
+        data,
+        "WARNING: While fetching all prompt templates PromptLayer had the following error"
+      );
+      return null;
+    }
+    return (data.items ?? []) as Promise<Array<GetPromptTemplateResponse>>;
+  } catch (e) {
+    console.warn(
+      `WARNING: While fetching all prompt templates PromptLayer had the following error: ${e}`
+    );
+    return null;
   }
 };
 
@@ -521,6 +551,7 @@ const throwOnBadResponse = (request_response: any, main_message: string) => {
 };
 
 export {
+  getAllPromptTemplates,
   getApiKey,
   getPromptTemplate,
   promptLayerAllPromptTemplates,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import {
   GetPromptTemplateParams,
   GetPromptTemplateResponse,
   LegacyPublishPromptTemplate,
+  ListPromptTemplatesResponse,
   Pagination,
   PublishPromptTemplate,
   PublishPromptTemplateResponse,
@@ -402,7 +403,7 @@ const getAllPromptTemplates = async (params?: Partial<Pagination>) => {
       );
       return null;
     }
-    return (data.items ?? []) as Promise<Array<GetPromptTemplateResponse>>;
+    return (data.items ?? []) as Promise<Array<ListPromptTemplatesResponse>>;
   } catch (e) {
     console.warn(
       `WARNING: While fetching all prompt templates PromptLayer had the following error: ${e}`


### PR DESCRIPTION
This pull request adds a new function called `getAllPromptTemplates` that fetches all prompt templates from the PromptLayer API. This function will be useful for retrieving a list of all available prompt templates in the application.