### PR TITLE
69 - Add `run` method to PromptLayer class for executing prompts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promptlayer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promptlayer",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.20.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.20.8",
         "@types/node": "^20.8.0",
-        "openai": "^4.28.4",
+        "openai": "^4.48.1",
         "tsup": "^7.2.0",
         "typescript": "^5.2.2"
       }
@@ -562,12 +562,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==",
-      "dev": true
-    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -621,15 +615,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -700,15 +685,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -733,16 +709,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/digest-fetch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
-      "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
-      "dev": true,
-      "dependencies": {
-        "base-64": "^0.1.0",
-        "md5": "^2.3.0"
       }
     },
     "node_modules/dir-glob": {
@@ -1044,12 +1010,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1136,17 +1096,6 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dev": true,
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -1371,16 +1320,15 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.28.4.tgz",
-      "integrity": "sha512-RNIwx4MT/F0zyizGcwS+bXKLzJ8QE9IOyigDG/ttnwB220d58bYjYFp0qjvGwEFBO6+pvFVIDABZPGDl46RFsg==",
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.48.1.tgz",
+      "integrity": "sha512-nlEzUAzDG1GsTlBVAFFtB0WZB8BFY+XU7o4oslzC7YMZ9PlgDixnbM49hXRWzv5OztevSn64hVKqptvzHq5/6Q==",
       "dev": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
         "abort-controller": "^3.0.0",
         "agentkeepalive": "^4.2.1",
-        "digest-fetch": "^1.3.0",
         "form-data-encoder": "1.7.2",
         "formdata-node": "^4.3.2",
         "node-fetch": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.20.8",
     "@types/node": "^20.8.0",
-    "openai": "^4.28.4",
+    "openai": "^4.48.1",
     "tsup": "^7.2.0",
     "typescript": "^5.2.2"
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "promptlayer",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,42 +89,42 @@ export class PromptLayer {
   }
 
   async run({
-    prompt_name,
-    prompt_version,
-    prompt_release_label,
+    promptName,
+    promptVersion,
+    promptReleaseLabel,
     inputVariables,
     tags,
     metadata,
-    group_id,
+    groupId: group_id,
     stream = false,
   }: RunRequest) {
     const prompt_input_variables = inputVariables;
     const templateGetParams: GetPromptTemplateParams = {
-      label: prompt_release_label,
-      version: prompt_version,
+      label: promptReleaseLabel,
+      version: promptVersion,
     };
     if (inputVariables) templateGetParams.input_variables = inputVariables;
     const promptBlueprint = await this.templates.get(
-      prompt_name,
+      promptName,
       templateGetParams
     );
     if (!promptBlueprint) throw new Error("Prompt not found");
     const promptTemplate = promptBlueprint.prompt_template;
     if (!promptBlueprint.llm_kwargs) {
       throw new Error(
-        `Prompt '${prompt_name}' does not have any LLM kwargs associated with it.`
+        `Prompt '${promptName}' does not have any LLM kwargs associated with it.`
       );
     }
     const promptBlueprintMetadata = promptBlueprint.metadata;
     if (!promptBlueprintMetadata) {
       throw new Error(
-        `Prompt '${prompt_name}' does not have any metadata associated with it.`
+        `Prompt '${promptName}' does not have any metadata associated with it.`
       );
     }
     const promptBlueprintModel = promptBlueprintMetadata.model;
     if (!promptBlueprintModel) {
       throw new Error(
-        `Prompt '${prompt_name}' does not have a model parameters associated with it.`
+        `Prompt '${promptName}' does not have a model parameters associated with it.`
       );
     }
     const provider_type = promptBlueprintModel.provider;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { GroupManager } from "@/groups";
 import { promptLayerBase } from "@/promptlayer";
 import { TemplateManager } from "@/templates";
 import { TrackManager } from "@/track";
-import { RunRequest } from "@/types";
+import { GetPromptTemplateParams, RunRequest } from "@/types";
 import {
   anthropicRequest,
   anthropicStreamCompletion,
@@ -90,15 +90,19 @@ export class PromptLayer {
 
   async run({
     prompt_name,
-    templateGetParams,
+    version,
+    label,
+    inputVariables,
     tags,
     metadata,
     group_id,
     stream = false,
   }: RunRequest) {
-    let prompt_input_variables = {};
-    if (templateGetParams?.input_variables)
-      prompt_input_variables = templateGetParams.input_variables;
+    const prompt_input_variables = inputVariables;
+    const templateGetParams: GetPromptTemplateParams = {};
+    if (version) templateGetParams.version = version;
+    if (label) templateGetParams.label = label;
+    if (inputVariables) templateGetParams.input_variables = inputVariables;
     const promptBlueprint = await this.templates.get(
       prompt_name,
       templateGetParams

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ export class PromptLayer {
     inputVariables,
     tags,
     metadata,
-    groupId: group_id,
+    groupId,
     stream = false,
   }: RunRequest) {
     const prompt_input_variables = inputVariables;
@@ -161,7 +161,7 @@ export class PromptLayer {
         prompt_id: promptBlueprint.id,
         prompt_version: promptBlueprint.version,
         prompt_input_variables,
-        group_id,
+        group_id: groupId,
         return_prompt_blueprint: true,
         ...body,
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,9 +125,13 @@ export class PromptLayer {
       prompt_version: promptBlueprint.version,
       prompt_input_variables,
       group_id,
-      return_data: true,
+      return_prompt_blueprint: true,
     });
-    requestLog["raw_response"] = request_response;
-    return requestLog;
+    const data = {
+      request_id: requestLog.request_id,
+      raw_response: request_response,
+      prompt_blueprint: requestLog.prompt_blueprint,
+    };
+    return data;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,24 @@ import { GroupManager } from "@/groups";
 import { promptLayerBase } from "@/promptlayer";
 import { TemplateManager } from "@/templates";
 import { TrackManager } from "@/track";
+import { RunRequest } from "@/types";
+import { anthropicRequest, openaiRequest, trackRequest } from "@/utils";
+
+const MAP_PROVIDER_TO_FUNCTION_NAME: Record<string, any> = {
+  openai: {
+    chat: "openai.chat.completions.create",
+    completion: "openai.completions.create",
+  },
+  anthropic: {
+    chat: "anthropic.messages.create",
+    completion: "anthropic.completions.create",
+  },
+};
+
+const MAP_PROVIDER_TO_FUNCTION: Record<string, any> = {
+  openai: openaiRequest,
+  anthropic: anthropicRequest,
+};
 
 export interface ClientOptions {
   apiKey?: string;
@@ -47,5 +65,69 @@ export class PromptLayer {
         "To use the Anthropic module, you must install the @anthropic-ai/sdk package."
       );
     }
+  }
+
+  async run({
+    prompt_name,
+    templateGetParams,
+    tags,
+    metadata,
+    group_id,
+  }: RunRequest) {
+    let prompt_input_variables = {};
+    if (templateGetParams?.input_variables)
+      prompt_input_variables = templateGetParams.input_variables;
+    const promptBlueprint = await this.templates.get(
+      prompt_name,
+      templateGetParams
+    );
+    if (!promptBlueprint) throw new Error("Prompt not found");
+    const promptTemplate = promptBlueprint.prompt_template;
+    if (!promptBlueprint.llm_kwargs) {
+      throw new Error(
+        `Prompt '${prompt_name}' does not have any LLM kwargs associated with it.`
+      );
+    }
+    const promptBlueprintMetadata = promptBlueprint.metadata;
+    if (!promptBlueprintMetadata) {
+      throw new Error(
+        `Prompt '${prompt_name}' does not have any metadata associated with it.`
+      );
+    }
+    const promptBlueprintModel = promptBlueprintMetadata.model;
+    if (!promptBlueprintModel) {
+      throw new Error(
+        `Prompt '${prompt_name}' does not have a model parameters associated with it.`
+      );
+    }
+    const provider_type = promptBlueprintModel.provider;
+    const requestStartTime = new Date().toISOString();
+    const kwargs = promptBlueprint.llm_kwargs;
+    const function_name =
+      MAP_PROVIDER_TO_FUNCTION_NAME[provider_type][promptTemplate.type];
+    const request_response = await MAP_PROVIDER_TO_FUNCTION[provider_type](
+      promptBlueprint,
+      kwargs
+    );
+    const requestEndTime = new Date().toISOString();
+    const requestLog = await trackRequest({
+      function_name,
+      provider_type,
+      args: [],
+      kwargs,
+      tags,
+      request_response,
+      request_start_time: requestStartTime,
+      request_end_time: requestEndTime,
+      api_key: this.apiKey,
+      metadata,
+      prompt_id: promptBlueprint.id,
+      prompt_version: promptBlueprint.version,
+      prompt_input_variables,
+      group_id,
+      return_data: true,
+    });
+    requestLog["raw_response"] = request_response;
+    return requestLog;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ export class PromptLayer {
     const request_function = MAP_PROVIDER_TO_FUNCTION[provider_type];
     const provider_base_url = promptBlueprint.provider_base_url;
     if (provider_base_url) {
-      kwargs["base_url"] = provider_base_url.url;
+      kwargs["baseURL"] = provider_base_url.url;
     }
     kwargs["stream"] = stream;
     if (stream && provider_type === "openai") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,8 +90,8 @@ export class PromptLayer {
 
   async run({
     prompt_name,
-    version,
-    label,
+    prompt_version,
+    prompt_release_label,
     inputVariables,
     tags,
     metadata,
@@ -99,9 +99,10 @@ export class PromptLayer {
     stream = false,
   }: RunRequest) {
     const prompt_input_variables = inputVariables;
-    const templateGetParams: GetPromptTemplateParams = {};
-    if (version) templateGetParams.version = version;
-    if (label) templateGetParams.label = label;
+    const templateGetParams: GetPromptTemplateParams = {
+      label: prompt_release_label,
+      version: prompt_version,
+    };
     if (inputVariables) templateGetParams.input_variables = inputVariables;
     const promptBlueprint = await this.templates.get(
       prompt_name,

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,6 +217,13 @@ export type PromptVersion = {
 export type PublishPromptTemplate = BasePromptTemplate &
   PromptVersion & { release_labels?: string[] };
 
+export interface ProviderBaseURL {
+  id: number;
+  name: string;
+  provider: string;
+  url: string;
+}
+
 export interface BasePromptTemplateResponse {
   id: number;
   prompt_name: string;
@@ -224,6 +231,7 @@ export interface BasePromptTemplateResponse {
   prompt_template: PromptTemplate;
   commit_message?: string;
   metadata?: Metadata;
+  provider_base_url?: ProviderBaseURL;
 }
 
 export interface PublishPromptTemplateResponse
@@ -245,4 +253,5 @@ export interface RunRequest {
   tags?: string[];
   metadata?: Record<string, string>;
   group_id?: number;
+  stream?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -253,7 +253,7 @@ export interface RunRequest {
   metadata?: Record<string, string>;
   group_id?: number;
   stream?: boolean;
-  version?: number;
-  label?: string;
+  prompt_version?: number;
+  prompt_release_label?: string;
   inputVariables?: Record<string, string>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,8 +67,8 @@ export interface Pagination {
 export interface GetPromptTemplateParams {
   version?: number;
   label?: string;
-  provider: string;
-  input_variables: Record<string, string>;
+  provider?: string;
+  input_variables?: Record<string, string>;
 }
 
 const templateFormat = ["f-string", "jinja2"] as const;
@@ -249,9 +249,11 @@ export interface ListPromptTemplatesResponse
 
 export interface RunRequest {
   prompt_name: string;
-  templateGetParams?: Partial<GetPromptTemplateParams>;
   tags?: string[];
   metadata?: Record<string, string>;
   group_id?: number;
   stream?: boolean;
+  version?: number;
+  label?: string;
+  inputVariables?: Record<string, string>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,8 @@ export interface TrackRequest {
   tags?: string[];
   request_response?: Record<string, unknown>;
   prompt_input_variables?: Record<string, string> | string[];
+  return_data?: boolean;
+  group_id?: number;
   [k: string]: unknown;
 }
 
@@ -212,7 +214,8 @@ export type PromptVersion = {
   metadata?: Metadata;
 };
 
-export type PublishPromptTemplate = BasePromptTemplate & PromptVersion & { release_labels?: string[] };
+export type PublishPromptTemplate = BasePromptTemplate &
+  PromptVersion & { release_labels?: string[] };
 
 export interface BasePromptTemplateResponse {
   id: number;
@@ -234,4 +237,12 @@ export interface GetPromptTemplateResponse extends BasePromptTemplateResponse {
 export interface ListPromptTemplatesResponse
   extends BasePromptTemplateResponse {
   version: number;
+}
+
+export interface RunRequest {
+  prompt_name: string;
+  templateGetParams?: Partial<GetPromptTemplateParams>;
+  tags?: string[];
+  metadata?: Record<string, string>;
+  group_id?: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -248,12 +248,12 @@ export interface ListPromptTemplatesResponse
 }
 
 export interface RunRequest {
-  prompt_name: string;
+  promptName: string;
   tags?: string[];
   metadata?: Record<string, string>;
-  group_id?: number;
+  groupId?: number;
   stream?: boolean;
-  prompt_version?: number;
-  prompt_release_label?: string;
+  promptVersion?: number;
+  promptReleaseLabel?: string;
   inputVariables?: Record<string, string>;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,9 +12,17 @@ import {
   TrackScore,
 } from "@/types";
 import type TypeAnthropic from "@anthropic-ai/sdk";
-import { Message, MessageStreamEvent } from "@anthropic-ai/sdk/resources";
+import {
+  Completion as AnthropicCompletion,
+  Message,
+  MessageStreamEvent,
+} from "@anthropic-ai/sdk/resources";
 import type TypeOpenAI from "openai";
-import { ChatCompletion, ChatCompletionChunk } from "openai/resources";
+import {
+  ChatCompletion,
+  ChatCompletionChunk,
+  Completion,
+} from "openai/resources";
 
 const URL_API_PROMPTLAYER = "https://api.promptlayer.com";
 
@@ -323,9 +331,7 @@ const getAllPromptTemplates = async (
   }
 };
 
-const mapChatCompletionChunk = (
-  results: ChatCompletionChunk[]
-): ChatCompletion => {
+const openaiStreamChat = (results: ChatCompletionChunk[]): ChatCompletion => {
   let content: ChatCompletion.Choice["message"]["content"] = null;
   let functionCall: ChatCompletion.Choice["message"]["function_call"] =
     undefined;
@@ -340,6 +346,7 @@ const mapChatCompletionChunk = (
   if (!lastResult) return response;
   let toolCalls: ChatCompletion.Choice["message"]["tool_calls"] = undefined;
   for (const result of results) {
+    if (result.choices.length === 0) continue;
     const delta = result.choices[0].delta;
 
     if (delta.content) {
@@ -379,9 +386,9 @@ const mapChatCompletionChunk = (
     }
   }
   response.choices.push({
-    finish_reason: lastResult.choices[0].finish_reason || "stop",
-    index: lastResult.choices[0].index || 0,
-    logprobs: lastResult.choices[0].logprobs || null,
+    finish_reason: results[0].choices[0].finish_reason || "stop",
+    index: results[0].choices[0].index || 0,
+    logprobs: results[0].choices[0].logprobs || null,
     message: {
       role: "assistant",
       content,
@@ -393,10 +400,11 @@ const mapChatCompletionChunk = (
   response.model = lastResult.model;
   response.created = lastResult.created;
   response.system_fingerprint = lastResult.system_fingerprint;
+  response.usage = lastResult.usage;
   return response;
 };
 
-const mapMessageStreamEvent = (results: MessageStreamEvent[]): Message => {
+const anthropicStreamMessage = (results: MessageStreamEvent[]): Message => {
   let response: Message = {
     id: "",
     model: "",
@@ -458,7 +466,7 @@ const cleaned_result = (
   }
 
   if (function_name === "anthropic.messages.create")
-    return mapMessageStreamEvent(results);
+    return anthropicStreamMessage(results);
 
   if ("text" in results[0].choices[0]) {
     let response = "";
@@ -471,7 +479,7 @@ const cleaned_result = (
   }
 
   if ("delta" in results[0].choices[0]) {
-    const response = mapChatCompletionChunk(results);
+    const response = openaiStreamChat(results);
     response.choices[0] = {
       ...response.choices[0],
       ...response.choices[0].message,
@@ -538,6 +546,86 @@ const trackRequest = async (body: TrackRequest) => {
   return {};
 };
 
+const openaiStreamCompletion = (results: Completion[]) => {
+  const response: Completion = {
+    id: "",
+    choices: [
+      {
+        finish_reason: "stop",
+        index: 0,
+        text: "",
+        logprobs: null,
+      },
+    ],
+    created: Date.now(),
+    model: "",
+    object: "text_completion",
+  };
+  const lastResult = results.at(-1);
+  if (!lastResult) return response;
+  let text = "";
+  for (const result of results) {
+    if (result.choices.length > 0 && result.choices[0].text) {
+      text = `${text}${result.choices[0].text}`;
+    }
+  }
+  response.choices[0].text = text;
+  response.id = lastResult.id;
+  response.created = lastResult.created;
+  response.model = lastResult.model;
+  response.system_fingerprint = lastResult.system_fingerprint;
+  response.usage = lastResult.usage;
+  return response;
+};
+
+const anthropicStreamCompletion = (results: AnthropicCompletion[]) => {
+  const response: AnthropicCompletion = {
+    completion: "",
+    id: "",
+    model: "",
+    stop_reason: "",
+    type: "completion",
+  };
+  const lastResult = results.at(-1);
+  if (!lastResult) return response;
+  let completion = "";
+  for (const result of results) {
+    completion = `${completion}${result.completion}`;
+  }
+  response.completion = completion;
+  response.id = lastResult.id;
+  response.model = lastResult.model;
+  response.stop_reason = lastResult.stop_reason;
+  return response;
+};
+
+async function* streamResponse<Item>(
+  generator: AsyncIterable<Item>,
+  afterStream: (body: object) => any,
+  mapResults: any
+) {
+  const data: {
+    request_id: number | null;
+    raw_response: any;
+    prompt_blueprint: any;
+  } = {
+    request_id: null,
+    raw_response: null,
+    prompt_blueprint: null,
+  };
+  const results = [];
+  for await (const result of generator) {
+    results.push(result);
+    data.raw_response = result;
+    yield data;
+  }
+  const request_response = mapResults(results);
+  const response = await afterStream({ request_response });
+  data.request_id = response.request_id;
+  data.prompt_blueprint = response.prompt_blueprint;
+  yield data;
+}
+
 const openaiChatRequest = async (client: TypeOpenAI, kwargs: any) => {
   return client.chat.completions.create(kwargs);
 };
@@ -591,9 +679,13 @@ const anthropicRequest = async (
 
 export {
   anthropicRequest,
+  anthropicStreamCompletion,
+  anthropicStreamMessage,
   getAllPromptTemplates,
   getPromptTemplate,
   openaiRequest,
+  openaiStreamChat,
+  openaiStreamCompletion,
   promptLayerApiRequest,
   promptLayerCreateGroup,
   promptLayerTrackGroup,
@@ -602,5 +694,6 @@ export {
   promptLayerTrackScore,
   promptlayerApiHandler,
   publishPromptTemplate,
+  streamResponse,
   trackRequest,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -644,7 +644,9 @@ const openaiRequest = async (
   kwargs: any
 ) => {
   const OpenAI = require("openai").default;
-  const client = new OpenAI();
+  const client = new OpenAI({
+    baseURL: kwargs.baseURL,
+  });
   const requestToMake =
     MAP_TYPE_TO_OPENAI_FUNCTION[promptBlueprint.prompt_template.type];
   return requestToMake(client, kwargs);
@@ -671,7 +673,9 @@ const anthropicRequest = async (
   kwargs: any
 ) => {
   const Anthropic = require("@anthropic-ai/sdk").default;
-  const client = new Anthropic();
+  const client = new Anthropic({
+    baseURL: kwargs.baseURL,
+  });
   const requestToMake =
     MAP_TYPE_TO_ANTHROPIC_FUNCTION[promptBlueprint.prompt_template.type];
   return requestToMake(client, kwargs);


### PR DESCRIPTION
This pull request adds a new `run` function to the `PromptLayer` class in the `promptlayer` package. The `run` function allows users to execute prompts with specified parameters, such as the prompt name, template parameters, tags, metadata, and group ID. This function handles the logic for making requests to different providers (OpenAI and Anthropic) based on the prompt template type. It also includes tracking functionality to log the request and response data.