### PR TITLE
75 - Fix input variables types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promptlayer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promptlayer",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.20.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "promptlayer",
   "license": "MIT",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export interface TrackRequest {
   metadata?: Record<string, string>;
   tags?: string[];
   request_response?: Record<string, unknown>;
-  prompt_input_variables?: Record<string, string> | string[];
+  prompt_input_variables?: Record<string, unknown> | string[];
   return_data?: boolean;
   group_id?: number;
   [k: string]: unknown;
@@ -68,7 +68,7 @@ export interface GetPromptTemplateParams {
   version?: number;
   label?: string;
   provider?: string;
-  input_variables?: Record<string, string>;
+  input_variables?: Record<string, unknown>;
   metadata_filters?: Record<string, string>;
 }
 
@@ -256,5 +256,5 @@ export interface RunRequest {
   stream?: boolean;
   promptVersion?: number;
   promptReleaseLabel?: string;
-  inputVariables?: Record<string, string>;
+  inputVariables?: Record<string, unknown>;
 }


### PR DESCRIPTION
This pull request fixes the input variable types in the code. The `prompt_input_variables` and `input_variables` properties now accept values of type `Record<string, unknown>` instead of `Record<string, string>`. This change ensures that the code can handle a wider range of input variable types.