### PR TITLE
Support using the environment variable `GEMINI_API_KEY` in addition to `GOOGLE_API_KEY`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -936,7 +936,7 @@ const googleRequest = async (
   kwargs: any
 ) => {
   const { GoogleGenerativeAI } = require("@google/generative-ai");
-  const genAI = new GoogleGenerativeAI(process.env.GOOGLE_API_KEY);
+  const genAI = new GoogleGenerativeAI(process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY);
   const requestToMake =
     MAP_TYPE_TO_GOOGLE_FUNCTION[promptBlueprint.prompt_template.type];
   


### PR DESCRIPTION
`promptlayer.run` requires `GOOGLE_API_KEY` to be set when using a Google model.

Add in support to also allow users to alternatively use `GEMINI_API_KEY` (official google docs [here](https://ai.google.dev/gemini-api/docs/api-key#macos---zsh) use `GEMINI_API_KEY` as the environment variable).

We already use `GOOGLE_API_KEY` elsewhere in our code base so we cannot set this environment variable.