### PR TITLE
Add prompt_id to LogRequest interface and update version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promptlayer",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promptlayer",
-      "version": "1.0.34",
+      "version": "1.0.35",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "promptlayer",
   "license": "MIT",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -333,6 +333,7 @@ export interface LogRequest {
   price?: number;
   function_name?: string;
   score?: number;
+  prompt_id?: number;
 }
 
 export interface RequestLog {


### PR DESCRIPTION
Introduce a new property, prompt_id, to the LogRequest interface and increment the package version to 1.0.35.