### PR TITLE
Bump version to 1.0.36 and improve generationConfig handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promptlayer",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promptlayer",
-      "version": "1.0.35",
+      "version": "1.0.36",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "promptlayer",
   "license": "MIT",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1154,6 +1154,10 @@ const googleRequest = async (
     MAP_TYPE_TO_GOOGLE_FUNCTION[promptBlueprint.prompt_template.type];
 
   const kwargsCamelCased = convertKeysToCamelCase(kwargs);
+  if (kwargsCamelCased.generationConfig)
+    kwargsCamelCased.generationConfig = convertKeysToCamelCase(
+      kwargsCamelCased.generationConfig
+    );
 
   return await requestToMake(genAI, kwargsCamelCased);
 };
@@ -1166,10 +1170,7 @@ const convertKeysToCamelCase = <T>(obj: T): T => {
   if (Array.isArray(obj)) return obj.map(convertKeysToCamelCase) as T;
 
   return Object.fromEntries(
-    Object.entries(obj).map(([key, value]) => [
-      snakeToCamel(key),
-      convertKeysToCamelCase(value),
-    ])
+    Object.entries(obj).map(([key, value]) => [snakeToCamel(key), value])
   ) as T;
 };
 


### PR DESCRIPTION
Update the package version to 1.0.36 and enhance the handling of generationConfig in utility functions for better key conversion.