### PR TITLE
Bump version to 1.0.43 and add model_parameter_overrides to GetPromptTemplateParams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promptlayer",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promptlayer",
-      "version": "1.0.42",
+      "version": "1.0.43",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "promptlayer",
   "license": "MIT",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,6 +153,7 @@ export class PromptLayer {
           metadata_filters: metadata,
           provider,
           model,
+          model_parameter_overrides: modelParameterOverrides,
         };
         if (inputVariables) templateGetParams.input_variables = inputVariables;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,7 @@ export interface GetPromptTemplateParams {
   input_variables?: Record<string, unknown>;
   metadata_filters?: Record<string, string>;
   model?: string;
+  model_parameter_overrides?: Record<string, unknown>;
 }
 
 const templateFormat = ["f-string", "jinja2"] as const;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1372,7 +1372,6 @@ const configureProviderSettings = (
 
   let kwargs = {
     ...(promptBlueprint.llm_kwargs || {}),
-    ...modelParameterOverrides,
     stream,
   };
 


### PR DESCRIPTION
Update the package version and introduce the `model_parameter_overrides` parameter in the `GetPromptTemplateParams` interface to enhance functionality.