### PR TITLE
fix: esm build is referenced correctly in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "version": "1.0.47",
   "main": "dist/index.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "private": false,
   "repository": {


### PR DESCRIPTION
The module build for this package was referencing a file that didn't exist.

Have updated the `package.json` to reference the final ESM build output.

This is stopping consuming of this library in any ESM builds.