### PR TITLE
Fix jq 1.6 compat in vendored Claude plugin, bump to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "promptlayer",
   "license": "MIT",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",

--- a/vendor/claude-agents/trace/hooks/lib.sh
+++ b/vendor/claude-agents/trace/hooks/lib.sh
@@ -500,7 +500,7 @@ build_span_json() {
 		--arg name "$name" \
 		--arg kind "$kind" \
 		--arg start "$start_ns" \
-		--arg end "$end_ns" \
+		--arg end_time "$end_ns" \
 		--argjson attributes "$attrs_json" \
 		'{
       traceId: $trace_id,
@@ -509,7 +509,7 @@ build_span_json() {
       name: $name,
       kind: $kind,
       startTimeUnixNano: $start,
-      endTimeUnixNano: $end,
+      endTimeUnixNano: $end_time,
       attributes: (
         $attributes
         | to_entries

--- a/vendor/claude-agents/vendor_metadata.json
+++ b/vendor/claude-agents/vendor_metadata.json
@@ -1,5 +1,5 @@
 {
   "repository": "https://github.com/MagnivOrg/promptlayer-claude-plugins",
-  "commit_sha": "7dff044080588cffb9b690fcdf772ee0b4f336da",
-  "timestamp": "2026-03-18T19:12:56.156Z"
+  "commit_sha": "f3796e77977c750a912f4b607bd162fdff5ce186",
+  "timestamp": "2026-03-19T22:27:47.129Z"
 }


### PR DESCRIPTION
## Summary
- Vendor latest `promptlayer-claude-plugins` (MagnivOrg/promptlayer-claude-plugins#6)
- Renames `$end` → `$end_time` jq variable in `build_span_json` — `$end` is reserved in jq 1.6 (Debian bookworm), causing spans to silently fail
- Bump version to 1.2.1

## Test plan
- [x] Verified in Modal sandbox with `debian_slim` (jq 1.6) — spans now export correctly
- [x] Traces visible in PromptLayer dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)