### PR TITLE
Bump package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promptlayer",
-  "version": "1.3.2",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promptlayer",
-      "version": "1.3.2",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "promptlayer",
   "license": "MIT",
-  "version": "1.3.2",
+  "version": "1.3.1",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
The previous release (v1.3.1) failed to deploy. This PR reverts the version back to v1.3.1 so it can be sent as a new one.